### PR TITLE
fix(sync): close the manifest over shell source, and detect vaults already clobbered

### DIFF
--- a/scripts/check-clobbered-vault-scripts.py
+++ b/scripts/check-clobbered-vault-scripts.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Detect vault scripts broken or silently reverted by a sync.
+
+`sync-vault-scripts.sh` propagates the repo's `scripts/` into a vault's
+`<meta>/scripts/`, overwriting whatever is there and keeping a `.bak-<stamp>`
+nobody reads. Two failure modes follow, both silent:
+
+  BROKEN-DEP  a synced script sources/imports a sibling that is NOT beside it.
+              Consumers ship without their dependency and fall back to a stub.
+              Measured: `vault-safe-commit.sh` fell to a fail-closed stub and
+              EVERY vault commit refused (it is the only route past the raw-git
+              block guard), while `session-end-hook.sh` fell to "defer" and
+              silently no-opped every session-end snapshot for two days.
+              Prevention now lives in test_vault_script_sync.sh section 1b; this
+              is the AT-REST leg for vaults synced before that gate existed.
+
+  REVERTED    a vault script is byte-identical to the repo copy AND differs from
+              the vault's own git HEAD. That means a local patch was overwritten
+              by the sync. Measured: a committed `--only` scoping fix was reverted
+              ~14h after it landed, because it had not been upstreamed yet, and
+              nothing said so. Closure gates cannot see this one — the file is
+              present and its dependencies resolve; it is simply the wrong version.
+
+Surfacer only: prints findings, never mutates, never auto-restores. Restoring is
+the operator's call because the local version is not always the one you want.
+
+Exit: 0 clean (or --surface), 1 findings, 2 could not run.
+
+Usage:
+  python3 check-clobbered-vault-scripts.py --vault /path/to/vault
+  python3 check-clobbered-vault-scripts.py --vault ... --surface   # always exit 0
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MAX_BYTES = 1_000_000  # bounded read: never slurp a huge or odd file
+
+# Shell: `. "$SCRIPT_DIR/_foo.sh"` / `source "$SCRIPTS/_foo.sh"`
+SH_DIRECT = re.compile(
+    r'^\s*(?:\.|source)\s+"?\$\{?(?:SCRIPT_DIR|SCRIPTS|SCRIPT_ROOT|HERE)\}?/'
+    r'([A-Za-z0-9_.-]+\.sh)"?',
+    re.M,
+)
+# Shell indirect: `GUARD="$SCRIPT_DIR/_foo.sh"` … later `. "$GUARD"`.
+# Not a nicety: the indirect form is the one that shipped the outage, and the
+# first version of this detector was blind to it — blind to the exact defect it
+# existed to catch.
+SH_ASSIGN = re.compile(
+    r'^\s*[A-Za-z_][A-Za-z0-9_]*=\s*"?\$\{?(?:SCRIPT_DIR|SCRIPTS|SCRIPT_ROOT|HERE)\}?/'
+    r'([A-Za-z0-9_.-]+\.sh)"?',
+    re.M,
+)
+# Python: `import _foo` / `from _foo import x`. Local-sibling modules only —
+# leading underscore is this repo's convention for a synced shared module.
+PY_IMPORT = re.compile(r'^\s*(?:from|import)\s+(_[A-Za-z0-9_]+)', re.M)
+
+
+def _read_bounded(p: Path) -> str | None:
+    # NOT named read_text: shadowing the stdlib Path method makes every call site
+    # indistinguishable from an un-encoded `path.read_text()` to the repo's static
+    # file-I/O encoding check, which is a conservative check worth keeping sharp.
+    try:
+        if p.stat().st_size > MAX_BYTES:
+            return None
+        return p.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+
+
+def find_meta_dir(vault_root: Path) -> Path | None:
+    """Locate the Meta folder. Mirrors _meta_resolver.find_meta_dir, inlined so
+    this script runs standalone from a vault that may not have the resolver yet
+    (a vault missing its scripts is exactly when you want to run this)."""
+    if not vault_root.is_dir():
+        return None
+    try:
+        candidates = [c for c in sorted(vault_root.iterdir())
+                      if c.is_dir() and c.name.endswith("Meta")]
+    except OSError:
+        return None
+    for c in candidates:
+        if (c / "Decisions").exists():
+            return c
+    return candidates[0] if candidates else None
+
+
+def git_head_bytes(repo: Path, rel: str) -> bytes | None:
+    try:
+        r = subprocess.run(["git", "-C", str(repo), "show", f"HEAD:{rel}"],
+                           capture_output=True, timeout=20)
+        return r.stdout if r.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def deps_of(path: Path, text: str) -> set[str]:
+    if path.suffix == ".sh":
+        return set(SH_DIRECT.findall(text)) | set(SH_ASSIGN.findall(text))
+    if path.suffix == ".py":
+        return {m + ".py" for m in PY_IMPORT.findall(text)}
+    return set()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vault", required=True)
+    ap.add_argument("--repo", default=None,
+                    help="repo whose scripts/ is the sync source "
+                         "(default: this script's parent dir)")
+    ap.add_argument("--surface", action="store_true",
+                    help="always exit 0 (fail-open for scheduled runs)")
+    args = ap.parse_args()
+
+    vault = Path(args.vault).expanduser()
+    src = Path(args.repo).expanduser() / "scripts" if args.repo \
+        else Path(__file__).resolve().parent
+
+    meta = find_meta_dir(vault)
+    if meta is None:
+        print(f"[clobber-check] no Meta dir under {vault} — nothing to check")
+        return 0
+    dest = meta / "scripts"
+    if not dest.is_dir():
+        print(f"[clobber-check] no scripts dir at {dest} — nothing to check")
+        return 0
+
+    broken: list[tuple[str, str]] = []
+    reverted: list[str] = []
+
+    for f in sorted(list(dest.glob("*.sh")) + list(dest.glob("*.py"))):
+        text = _read_bounded(f)
+        if text is None:
+            continue
+
+        for dep in sorted(deps_of(f, text)):
+            if not (dest / dep).exists():
+                broken.append((f.name, dep))
+
+        twin = src / f.name
+        if not twin.is_file():
+            continue
+        try:
+            local, shipped = f.read_bytes(), twin.read_bytes()
+        except OSError:
+            continue
+        if local != shipped:
+            continue  # diverged from shipped == normal for a vault-local file
+        rel = f"{meta.name}/scripts/{f.name}"
+        head = git_head_bytes(vault, rel)
+        if head is not None and head != local:
+            reverted.append(f.name)
+
+    if not broken and not reverted:
+        print("[clobber-check] clean — no broken sibling deps, no reverted scripts")
+        return 0
+
+    print("[clobber-check] FINDINGS")
+    for name, dep in broken:
+        print(f"  BROKEN-DEP  {name} needs sibling '{dep}', which is NOT in "
+              f"{dest}.")
+        print(f"              It is running its fallback stub. If this script is "
+              f"a guard's only sanctioned path, that is an OUTAGE.")
+        print(f"              Fix: add '{dep}' to VAULT_SCRIPTS in "
+              f"sync-vault-scripts.sh, then re-sync.")
+    for name in reverted:
+        print(f"  REVERTED    {name} is byte-identical to the shipped copy but "
+              f"differs from vault HEAD —")
+        print(f"              a sync overwrote a local patch. Check for a "
+              f"'{name}.bak-*' beside it.")
+        print(f"              If the local version was right, UPSTREAM it — "
+              f"otherwise the next sync reverts it again.")
+
+    return 0 if args.surface else 1
+
+
+if __name__ == "__main__":
+    # Windows cp1252-console safety (#313): force UTF-8 so a non-ASCII print can't
+    # crash. This script's findings carry em dashes, and a detector that dies while
+    # reporting a defect is worse than one that never ran.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")  # Python 3.7+
+        except (AttributeError, ValueError):
+            pass
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(2)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -375,6 +375,13 @@ INTEGRATION_TESTS=(
   # to stdout and never writes the log, so a "(dry-run)" header IN the log was
   # unreachable except as a mislabel.
   test_sync_vault_scripts_dryrun_label
+  # At-rest leg of the sync-clobber class. test_vault_script_sync.sh section 1b
+  # PREVENTS a manifest gap; this detects vaults already damaged, plus the case
+  # closure cannot see — a committed local patch silently overwritten by the sync
+  # (file present, deps resolve, simply the wrong version). Every assertion is a
+  # negative control, including the indirect `VAR="$SCRIPT_DIR/x.sh"` form that
+  # shipped the real outage and that the first draft of the detector was blind to.
+  test_clobbered_vault_scripts
   # vault-safe-commit.sh is the ONLY sanctioned route past the raw-git block
   # guard, so a bare `git commit -m` there gave that guard zero real scoping
   # while it looked fully enforced — a sibling session's staged work rode along

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -203,6 +203,31 @@ else
   warn "graph-context-hook.sh not in ⚙️ Meta/scripts/" "Phase 5 installs it."
 fi
 
+# Sync-clobber check: a synced script whose sibling dependency did not come along
+# (it is silently running a fallback stub), or a local patch the sync overwrote.
+# Measured incident: the commit wrapper fell to a fail-closed stub and EVERY vault
+# commit refused for ~19h, while the session-end hook fell to "defer" and silently
+# skipped every snapshot. Neither surfaced anywhere until a detector existed.
+# Resolved from this script's own location: diagnose.sh defines no repo variable,
+# and a `[ -f "$UNSET/..." ]` guard would make this check a silent no-op — the
+# exact failure class it exists to catch.
+_ABS_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"
+CLOBBER="$_ABS_REPO/scripts/check-clobbered-vault-scripts.py"
+if [ -f "$CLOBBER" ] && command -v python3 >/dev/null 2>&1; then
+  CLOBBER_OUT=$(python3 "$CLOBBER" --vault "$VAULT" --repo "$_ABS_REPO" 2>&1)
+  if [ $? -eq 0 ]; then
+    ok "vault scripts: no broken sibling deps, none reverted by a sync"
+  else
+    # Report each finding on its own line so the remedy is actionable, not a blob.
+    printf '%s\n' "$CLOBBER_OUT" | grep -E '^\s+(BROKEN-DEP|REVERTED)' | while IFS= read -r l; do
+      warn "$(printf '%s' "$l" | sed 's/^[[:space:]]*//')"
+    done
+    warn "vault scripts need attention" "Full detail: python3 '$CLOBBER' --vault '$VAULT'"
+  fi
+else
+  warn "sync-clobber check did not run" "Missing $CLOBBER or python3 — this check is INACTIVE, not passing."
+fi
+
 # ----- 5. Journal index -----
 section "5. Insights pipeline"
 INDEX="$META/journal-index.json"

--- a/scripts/sync-vault-scripts.sh
+++ b/scripts/sync-vault-scripts.sh
@@ -90,6 +90,14 @@ done
 VAULT_SCRIPTS=(
   "_meta_resolver.py"          # shared meta-folder resolver (deterministic keystone)
   "_project_key.py"            # shared project-key resolver (dep of check-rule-conflicts.py)
+  "_session_close_guard.sh"    # shared git-dir/index-lock resolver — sourced by BOTH
+                               # vault-safe-commit.sh and session-end-hook.sh. Omitting
+                               # it shipped the consumers without their dependency: the
+                               # commit wrapper fell to a fail-closed stub and EVERY vault
+                               # commit refused (it is the only route past the raw-git
+                               # block guard), while session-end-hook fell to "defer" and
+                               # silently no-opped every session-end snapshot. Section 1b
+                               # of test_vault_script_sync.sh now fails on this class.
   "aggregate-sessions.py"      # session-close: Last Session.md index
   "aggregate-decisions.py"     # session-close: Decision Log index
   "session-close-runner.sh"    # session-close: deterministic aggregation runner (#173)

--- a/tests/integration/test_clobbered_vault_scripts.sh
+++ b/tests/integration/test_clobbered_vault_scripts.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# test_clobbered_vault_scripts.sh
+#
+# check-clobbered-vault-scripts.py is the AT-REST leg for the sync-clobber class.
+# test_vault_script_sync.sh section 1b PREVENTS a manifest gap going forward; this
+# detects vaults already damaged, plus the one case closure cannot see — a local
+# patch silently overwritten by the sync (the file is present and its deps resolve,
+# it is simply the wrong version).
+#
+# Every assertion is a NEGATIVE control: a fixture is planted with the real defect
+# and the detector must FIRE, then the defect is removed and it must go clean. A
+# detector that has never failed on the thing it catches is unproven.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CHECK="$REPO_ROOT/scripts/check-clobbered-vault-scripts.py"
+
+FAILED=0
+pass() { printf '  PASS: %s\n' "$1"; }
+fail() { printf '  FAIL: %s\n' "$1"; FAILED=1; }
+
+echo "test_clobbered_vault_scripts"
+
+[ -f "$CHECK" ] || { echo "  FAIL: $CHECK not found"; exit 1; }
+
+# Fixture: a vault with a git repo and a fake "repo scripts" source dir.
+make_vault() {  # -> echoes <tmp>; <tmp>/vault and <tmp>/src exist
+    local t; t=$(mktemp -d)
+    mkdir -p "$t/vault/⚙️ Meta/scripts" "$t/vault/⚙️ Meta/Decisions" "$t/scripts"
+    git -C "$t/vault" init --quiet
+    git -C "$t/vault" config user.email t@e.com
+    git -C "$t/vault" config user.name t
+    echo "$t"
+}
+commit_all() { git -C "$1/vault" add -A >/dev/null 2>&1; git -C "$1/vault" commit --quiet -m base >/dev/null 2>&1; }
+run_check() { python3 "$CHECK" --vault "$1/vault" --repo "$1" 2>&1; }
+
+# --- 1. BROKEN-DEP, shell DIRECT form ---------------------------------------
+T=$(make_vault)
+printf '#!/bin/bash\nSCRIPT_DIR=x\n. "$SCRIPT_DIR/_guard.sh"\n' > "$T/vault/⚙️ Meta/scripts/w.sh"
+commit_all "$T"
+out=$(run_check "$T"); rc=$?
+if [ $rc -eq 1 ] && printf '%s' "$out" | grep -q "BROKEN-DEP"; then
+    pass "fires on a shell script sourcing an absent sibling (direct form)"
+else
+    fail "missed direct-form broken dep (rc=$rc): $out"
+fi
+printf '#!/bin/bash\n' > "$T/vault/⚙️ Meta/scripts/_guard.sh"
+out=$(run_check "$T"); rc=$?
+[ $rc -eq 0 ] && pass "goes clean once the sibling is present" \
+              || fail "still firing after the sibling was added: $out"
+rm -rf "$T"
+
+# --- 2. BROKEN-DEP, shell INDIRECT form (the one that shipped the outage) ----
+T=$(make_vault)
+printf '#!/bin/bash\nSCRIPT_DIR=x\nG="$SCRIPT_DIR/_guard.sh"\nif [ -f "$G" ]; then . "$G"; fi\n' \
+    > "$T/vault/⚙️ Meta/scripts/w.sh"
+commit_all "$T"
+out=$(run_check "$T"); rc=$?
+if [ $rc -eq 1 ] && printf '%s' "$out" | grep -q "BROKEN-DEP"; then
+    pass "fires on the INDIRECT assignment form (VAR=... then . \"\$VAR\")"
+else
+    fail "missed indirect-form broken dep — the real incident shape (rc=$rc): $out"
+fi
+rm -rf "$T"
+
+# --- 3. BROKEN-DEP, python sibling import -----------------------------------
+T=$(make_vault)
+printf 'import _helper\n' > "$T/vault/⚙️ Meta/scripts/w.py"
+commit_all "$T"
+out=$(run_check "$T"); rc=$?
+if [ $rc -eq 1 ] && printf '%s' "$out" | grep -q "BROKEN-DEP"; then
+    pass "fires on a python script importing an absent sibling module"
+else
+    fail "missed python sibling import (rc=$rc): $out"
+fi
+rm -rf "$T"
+
+# --- 4. REVERTED: local patch overwritten by the sync ------------------------
+# HEAD holds the patched version; the working tree holds the shipped version.
+# Closure cannot see this: the file is present and has no dependencies.
+T=$(make_vault)
+printf '#!/bin/bash\n# local fix v2\n' > "$T/vault/⚙️ Meta/scripts/w.sh"
+commit_all "$T"
+printf '#!/bin/bash\n# upstream v1\n' > "$T/scripts/w.sh"
+cp "$T/scripts/w.sh" "$T/vault/⚙️ Meta/scripts/w.sh"      # <- the clobber
+out=$(run_check "$T"); rc=$?
+if [ $rc -eq 1 ] && printf '%s' "$out" | grep -q "REVERTED"; then
+    pass "fires when a committed local patch was overwritten by the shipped copy"
+else
+    fail "missed the reverted-local-patch case (rc=$rc): $out"
+fi
+# and must NOT fire when the vault copy legitimately differs from shipped
+printf '#!/bin/bash\n# local fix v2\n' > "$T/vault/⚙️ Meta/scripts/w.sh"
+out=$(run_check "$T"); rc=$?
+[ $rc -eq 0 ] && pass "silent when the vault copy legitimately differs from shipped" \
+              || fail "false positive on a legitimately-diverged vault file: $out"
+rm -rf "$T"
+
+# --- 5. --surface is fail-open ----------------------------------------------
+T=$(make_vault)
+printf '#!/bin/bash\nSCRIPT_DIR=x\n. "$SCRIPT_DIR/_gone.sh"\n' > "$T/vault/⚙️ Meta/scripts/w.sh"
+commit_all "$T"
+python3 "$CHECK" --vault "$T/vault" --repo "$T" --surface >/dev/null 2>&1
+[ $? -eq 0 ] && pass "--surface exits 0 even with findings (safe for cron)" \
+             || fail "--surface did not fail open"
+rm -rf "$T"
+
+# --- 6. a vault with no Meta dir is a clean no-op, not a crash ---------------
+T=$(mktemp -d); mkdir -p "$T/scripts"
+python3 "$CHECK" --vault "$T" --repo "$T" >/dev/null 2>&1
+[ $? -eq 0 ] && pass "no Meta dir is a clean no-op" || fail "crashed on a vault with no Meta dir"
+rm -rf "$T"
+
+[ $FAILED -eq 0 ] && echo "OK" || echo "FAILURES"
+exit $FAILED

--- a/tests/integration/test_vault_script_sync.sh
+++ b/tests/integration/test_vault_script_sync.sh
@@ -174,6 +174,71 @@ if missing:
 print(f"PASS: manifest import-closed ({len(py)} py scripts checked, {len(names)} total)")
 PY
 
+# --- 1b. manifest SOURCE-closure (shell) ----------------------------------
+# Section 1 walks Python ASTs and reports "N py scripts checked". Shell scripts
+# were never scanned, so a manifest .sh could `source` a sibling that the sync
+# does not carry — and did.
+#
+# Measured incident: `vault-safe-commit.sh` and `session-end-hook.sh` are both in
+# the manifest and both source `_session_close_guard.sh`, which is NOT. The sync
+# copied the consumers without the dependency. `vault-safe-commit.sh` falls back
+# to a fail-closed stub, so EVERY vault commit refused — and it is the only route
+# past the raw-git block guard, so committing stopped entirely. `session-end-hook.sh`
+# falls back to "defer", so every session-end snapshot silently no-opped.
+#
+# Both the direct form (`. "$SCRIPT_DIR/x.sh"`) and the indirect one
+# (`GUARD="$SCRIPT_DIR/x.sh"` … `. "$GUARD"`) must be caught: the indirect form is
+# the one that shipped the outage.
+python3 - "$REPO_ROOT" "$SYNC" <<'PY'
+import os, re, sys
+repo, sync = sys.argv[1], sys.argv[2]
+lines = open(sync, encoding="utf-8").read().splitlines()
+start = next((i for i, l in enumerate(lines) if "VAULT_SCRIPTS=(" in l), None)
+assert start is not None, "VAULT_SCRIPTS array not found"
+names = []
+for l in lines[start + 1:]:
+    if l.strip() == ")":
+        break
+    m = re.match(r'\s*"([^"]+)"', l)
+    if m:
+        names.append(m.group(1))
+
+DIRECT = re.compile(
+    r'^\s*(?:\.|source)\s+"?\$\{?(?:SCRIPT_DIR|SCRIPTS|SCRIPT_ROOT|HERE)\}?/([A-Za-z0-9_.-]+\.sh)"?',
+    re.M)
+ASSIGN = re.compile(
+    r'^\s*[A-Za-z_][A-Za-z0-9_]*=\s*"?\$\{?(?:SCRIPT_DIR|SCRIPTS|SCRIPT_ROOT|HERE)\}?/([A-Za-z0-9_.-]+\.sh)"?',
+    re.M)
+
+sh = [n for n in names if n.endswith(".sh")]
+missing, checked = [], 0
+for n in sh:
+    p = os.path.join(repo, "scripts", n)
+    if not os.path.exists(p):
+        continue  # source-absent on this checkout (e.g. pre-merge) — skip
+    checked += 1
+    text = open(p, encoding="utf-8", errors="replace").read()
+    for dep in sorted(set(DIRECT.findall(text)) | set(ASSIGN.findall(text))):
+        if dep in names:
+            continue
+        where = os.path.join(repo, "scripts", dep)
+        if not os.path.exists(where):
+            missing.append(
+                f"{n} sources sibling '{dep}', which is not in the manifest AND "
+                f"does not exist in scripts/ — dangling reference.")
+        else:
+            missing.append(
+                f"{n} sources sibling '{dep}' from scripts/{dep}, which is NOT in "
+                f"VAULT_SCRIPTS, so the synced vault copy falls back to its stub. "
+                f"Add '{dep}' to the manifest.")
+if missing:
+    print("SOURCE-CLOSURE FAIL:")
+    for x in missing:
+        print("  -", x)
+    sys.exit(1)
+print(f"PASS: manifest source-closed ({checked} sh scripts checked, {len(names)} total)")
+PY
+
 # --- 2. fresh sync populates <meta>/scripts/ ------------------------------
 VAULT="$TMP/vault"; mkdir -p "$VAULT/⚙️ Meta"
 bash "$SYNC" --vault "$VAULT" --quiet >/dev/null


### PR DESCRIPTION
`sync-vault-scripts.sh` copied `vault-safe-commit.sh` and `session-end-hook.sh` into vaults **without** `_session_close_guard.sh`, which both of them source. Each fell back to its stub: the commit wrapper fails closed, and it is the only route past the raw-git block guard, so **every vault commit refused for ~19h**; the session-end hook defers, so **every session-end snapshot silently no-opped** for two days with no error.

The root cause is the manifest's closure gate. Section 1 of the sync self-test walks Python ASTs and reports "N py scripts checked" — **shell was never scanned**, so a manifest `.sh` could source a sibling the sync does not carry. And did.

## Three parts

**1. `_session_close_guard.sh` added to `VAULT_SCRIPTS`.** The `.ps1` twin parses the manifest out of the `.sh`, so one edit covers both platforms — no parity gap.

**2. New section 1b: manifest SOURCE-closure for shell.** Covers the direct form (`. "$SCRIPT_DIR/x.sh"`) and the indirect one (`G="$SCRIPT_DIR/x.sh"` … `. "$G"`). The indirect form is the one that shipped the outage. Run against the manifest *before* part 1, it fails and names both victims — that is its negative control, and it is the assertion that would have stopped this at CI.

**3. `check-clobbered-vault-scripts.py`** — the at-rest leg for vaults synced before this gate existed. Flags `BROKEN-DEP` (sibling absent, script silently running a stub) and `REVERTED` (byte-identical to the shipped copy while differing from vault HEAD, i.e. a local patch the sync overwrote). Covers `.py` sibling imports as well as `.sh`.

`REVERTED` is the case closure structurally cannot see: the file is present and its dependencies resolve, it is simply the wrong version. Measured on a real vault — a committed scoping fix was reverted ~14h after it landed because it had not been upstreamed, and nothing said so.

## Activation

Wired into `diagnose.sh`, so a client sees it without running anything new.

That block resolves the repo from its own location: `diagnose.sh` defines no repo variable, and an unset one inside `[ -f ... ]` would have made the whole check a **silent no-op** — the exact class being fixed. It also emits a WARN when it could not run, because "inactive" must never read as "passing".

## Review-risky areas

- The shell-source regexes recognise `$SCRIPT_DIR`/`$SCRIPTS`/`$SCRIPT_ROOT`/`$HERE`. A script using a different variable name for its own directory would not be scanned. That is a deliberate floor, not full shell parsing.
- `REVERTED` compares against vault `HEAD`, so it is silent in a vault that is not a git repo. Intentional: there is no baseline to compare against.
- Adding a file to `VAULT_SCRIPTS` changes what every client receives on next sync. Correct here — the dependency must travel with its consumers — but it is a behaviour change, not just a test.

## Verification

Every assertion in the new detector test is a negative control: plant the real defect, require it to fire, remove it, require clean. Includes the indirect-assignment form that the first draft of the detector was blind to — blind to the exact defect it existed to catch, caught only by running it against a live vault.

Drafted with Claude Code; gate run and diff reviewed before push.
