### PR TITLE
fix(journal-guard): resolve vault root for cd-relative saves; revive vault script sync

### DIFF
--- a/hooks/warn-journal-saved-without-context.py
+++ b/hooks/warn-journal-saved-without-context.py
@@ -31,6 +31,7 @@ edits to an already-contextualized entry.
 import json
 import os
 import re
+import shutil
 import sys
 import datetime
 from pathlib import Path
@@ -73,19 +74,64 @@ def _norm(text):
 
 
 def _vault_root(text):
-    """Absolute dir before the '<optional emoji >Journals/<Month YYYY>/' segment.
+    """Absolute dir before the '<optional emoji >Journals/<Month YYYY>/' segment,
+    or None when the text carries no absolute journal path (see _resolve_vault).
     Anchored on the absolute path (starts at a real '/', or a `C:/` drive root),
     so a leading shell prefix like `cat > '/vault/.../x.md'` is NOT captured into
     the root (that was the 2026-07-07 Bash-path fail-open bug). Quotes bound the
     segment on the Bash path.
 
     The drive-letter alternative is guarded by `(?<![A-Za-z])` so a URL like
-    `http://host/Journals/May 2026/` cannot have its `p:` read as a drive."""
+    `http://host/Journals/May 2026/` cannot have its `p:` read as a drive.
+
+    The optional folder-prefix segment excludes quotes and shell metacharacters,
+    not just '/'. With the looser `[^/\n]*` it spanned shell syntax: the
+    cwd-relative save idiom
+        cd "/Users/x/Brain" && cat > "<emoji> Journals/Aug 2026/e.md"
+    let the segment swallow `Brain" && cat > "<emoji> `, collapsing the root to
+    the vault's PARENT. That parent is a real directory, so the guard did not
+    fail open — it blocked while naming a marker path no preflight can ever
+    create, making the guard unsatisfiable and the bypass routine (2026-08-30)."""
     m = re.search(
-        r"((?:(?<![A-Za-z])[A-Za-z]:)?/[^\n\"']*?)/(?:[^/\n]*\s)?"
+        r"((?:(?<![A-Za-z])[A-Za-z]:)?/[^\n\"']*?)/(?:[^/\n\"'|&;<>]*\s)?"
         r"Journals/[A-Z][a-zA-Z]+\s+\d{4}/",
         text)
     return m.group(1) if m else None
+
+
+# Leading `cd <dir>` of a command segment; quoted or bare. Used only to resolve a
+# RELATIVE journal path, which is how daily-journal actually saves.
+# The leading class accepts a quote and `(` as well as the shell separators, so a
+# wrapped form (`bash -c 'cd "<vault>" && cat > ...'`, a subshell) still yields the
+# cd target. Without them such a command fell through to the cwd fallback, which
+# in a worktree session is NOT the vault — reproducing the same unsatisfiable
+# block this hook was just fixed to stop emitting.
+CD_TARGET_RE = re.compile(
+    r"""(?:^|[;&|(\n"']|\bthen\b|\bdo\b)\s*cd\s+(?:-{1,2}\S+\s+)*"""
+    r"""(?:"([^"\n]+)"|'([^'\n]+)'|([^\s;&|<>()]+))""")
+
+
+def _cd_target(text, cwd=None):
+    """Destination of the command's first `cd`, expanded and made absolute."""
+    m = CD_TARGET_RE.search(text)
+    if not m:
+        return None
+    d = os.path.expanduser(next(g for g in m.groups() if g is not None))
+    if not os.path.isabs(d) and not re.match(r"^[A-Za-z]:/", d):
+        if not cwd:
+            return None
+        d = os.path.normpath(os.path.join(cwd, d))
+    return d.rstrip("/") or "/"
+
+
+def _resolve_vault(text, cwd):
+    """Vault root for this save. An absolute journal path wins; otherwise the
+    path is relative to the shell's cwd, so fall back to the command's own `cd`
+    target and then to the session cwd from the hook payload. Without these
+    fallbacks the tightened regex above would return None for the relative
+    idiom and the guard would silently stop protecting the primary save path —
+    trading a wrong block for a quiet hole."""
+    return _vault_root(text) or _cd_target(text, cwd) or cwd
 
 
 def _marker_exists(vault, date_iso):
@@ -126,7 +172,7 @@ elif tool_name == "Bash":
 if not blob:
     sys.exit(0)  # not a journal save
 
-vault = _vault_root(blob)
+vault = _resolve_vault(blob, payload.get("cwd") or None)
 if not vault or not os.path.isdir(vault):
     sys.exit(0)  # can't locate vault -> fail open
 
@@ -136,15 +182,29 @@ date_iso = dm.group(1) if dm else _target_today()
 if _marker_exists(vault, date_iso):
     sys.exit(0)  # preflight ran for this date -> allow
 
+# Name the meta dir this vault actually uses, and an interpreter that actually
+# runs here: a remediation the operator cannot execute is why the bypass became
+# routine. `uv run python3` where uv is installed (a bare `python3` is shimmed
+# and errors out on such boxes), else the very interpreter running this hook.
+_meta = next((m for m in ("⚙️ Meta", "Meta")
+              if os.path.isdir(os.path.join(vault, m))), "⚙️ Meta")
+_py = "uv run python3" if shutil.which("uv") else (sys.executable or "python3")
+_preflight = os.path.join(vault, _meta, "scripts", "journal-preflight.py")
+_missing = "" if os.path.exists(_preflight) else (
+    "\n!! That script is MISSING from this vault. Install it with:\n"
+    f'   VAULT_ROOT="{vault}" bash '
+    '~/.claude/skills/ai-brain-starter/scripts/sync-vault-scripts.sh\n')
+
 err = (
     "BLOCKED by warn-journal-saved-without-context hook.\n\n"
     f"No preflight marker for {date_iso} at\n"
-    f"  {vault}/⚙️ Meta/.journal-context/{date_iso}.json\n"
+    f"  {os.path.join(vault, _meta, '.journal-context', date_iso + '.json')}\n"
     "-> Step 0's context pull never ran, so this journal would ship with no\n"
     "calendar / messages / RescueTime / activity context. That is the exact\n"
     "2026-07-07 failure this guard exists to stop.\n\n"
     "Fix (do this, then re-issue the save):\n"
-    '  1. python3 "⚙️ Meta/scripts/journal-preflight.py"\n'
+    f'  1. {_py} "{_preflight}"\n'
+    f"{_missing}"
     "  2. Make the calendar + email + Slack + health MCP pulls it prints.\n"
     "  3. Fold the context into ## Today + a context_sources: frontmatter block.\n\n"
     "Bypass (addendum / pre-contextualized entry): JOURNAL_CONTEXT_BYPASS=1"

--- a/scripts/sync-vault-scripts.sh
+++ b/scripts/sync-vault-scripts.sh
@@ -140,19 +140,32 @@ fi
 # pops the Store, so the resolver call came back EMPTY and this script misread
 # it as "no Meta folder" and silently no-opped (issue #375). Trust only a
 # candidate that actually reports major version 3.
+#
+# The same failure has a second cause on macOS/Linux: a Claude Code plugin can
+# put a WRAPPER named `python3` (and `python`) ahead of the real interpreter on
+# PATH — the trailofbits modern-python shim refuses a bare call outright
+# ("Use `uv run python3 ...` instead"). Both candidates then satisfy
+# `command -v`, both fail the probe, `py` does not exist off Windows, and
+# PY_CMD ends up EMPTY -> "no Meta folder" -> a silent no-op that kept
+# journal-preflight.py out of the vault entirely (found 2026-08-30: the
+# /journal Step-0 guard was left unsatisfiable because its script never
+# shipped). So the list continues past a shimmed PATH: an explicit $PYTHON
+# first, then `uv run python3`, then absolute interpreter paths a PATH shim
+# cannot shadow. The probe stays the sole arbiter — a candidate is used only if
+# it actually reports major version 3.
 PY_CMD=""
 _probe_python() {
   [ "$("$@" -c 'import sys; print(sys.version_info[0])' 2>/dev/null \
         | head -n1 | tr -d '\r')" = "3" ]
 }
-for _cand in python3 python py; do
-  command -v "$_cand" >/dev/null 2>&1 || continue
-  if [ "$_cand" = "py" ]; then
-    # The Windows launcher needs -3 to guarantee a Python 3 interpreter.
-    _probe_python py -3 && { PY_CMD="py -3"; break; }
-  else
-    _probe_python "$_cand" && { PY_CMD="$_cand"; break; }
-  fi
+_probe_cmd() {  # candidate may be multi-word ("py -3", "uv run python3")
+  # shellcheck disable=SC2086  # word-splitting the candidate is the point
+  _probe_python $1
+}
+for _cand in ${PYTHON:+"$PYTHON"} python3 python "py -3" "uv run python3" \
+             /opt/homebrew/bin/python3 /usr/local/bin/python3 /usr/bin/python3; do
+  command -v "${_cand%% *}" >/dev/null 2>&1 || continue
+  _probe_cmd "$_cand" && { PY_CMD="$_cand"; break; }
 done
 unset _cand
 

--- a/skills/daily-journal/SKILL.md
+++ b/skills/daily-journal/SKILL.md
@@ -157,10 +157,10 @@ One calendar day = ONE journal entry that grows across sessions (an afternoon ch
 **0-RUN. Run the preflight FIRST — this is the literal first tool call of every `/journal`, before the opener. Non-negotiable.**
 
 ```
-python3 "⚙️ Meta/scripts/journal-preflight.py"
+uv run python3 "⚙️ Meta/scripts/journal-preflight.py"
 ```
 
-(or `Meta/scripts/journal-preflight.py` if the vault doesn't use emoji-prefixed Meta.) It auto-spans since the last entry, pulls every SCRIPT source into ONE digest — messages (WhatsApp direct + groups + iMessage, whole gap, FAMILY/PARTNER threads surfaced first with ⭐), RescueTime (per day), close-cascade journal seeds (Session Captures), today's activity, the email triage digest, and the on-disk Slack export — and writes a marker at `⚙️ Meta/.journal-context/<date>.json`. It cannot call MCP, so it prints the exact MCP pulls you MUST make yourself right after — make EVERY one it lists:
+(or `Meta/scripts/journal-preflight.py` if the vault doesn't use emoji-prefixed Meta. Use a bare `python3` only where that is a REAL interpreter: a Claude Code plugin can put a shim named `python3` ahead of it on PATH, and the bare call then errors out instead of running — which is how this preflight went unrun. `uv run python3` is immune to that. If the save-time guard blocks you, it prints the exact working command for this vault.) It auto-spans since the last entry, pulls every SCRIPT source into ONE digest — messages (WhatsApp direct + groups + iMessage, whole gap, FAMILY/PARTNER threads surfaced first with ⭐), RescueTime (per day), close-cascade journal seeds (Session Captures), today's activity, the email triage digest, and the on-disk Slack export — and writes a marker at `⚙️ Meta/.journal-context/<date>.json`. It cannot call MCP, so it prints the exact MCP pulls you MUST make yourself right after — make EVERY one it lists:
 
 1. **Calendar** — `cal_list_events(time_min, time_max)` for the window; fold meetings + attendees into `## Today`.
 2. **Email (fresh, relational)** — `gmail_search` each account since the last entry; surface FAMILY / friends / commitments, not just the (often stale) triage digest the preflight already read.

--- a/tests/integration/test_journal_guard_relative_cd_path.sh
+++ b/tests/integration/test_journal_guard_relative_cd_path.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Integration test: warn-journal-saved-without-context.py resolves the vault root
+# for the `cd <vault> && cat > "<relative journal path>"` save idiom.
+#
+# THE BUG (found 2026-08-30, /journal session)
+#   daily-journal saves with the cwd-relative idiom:
+#     cd "/Users/x/Brain" && cat > "📓 Journals/August 2026/entry.md" << 'EOF'
+#   _vault_root()'s optional emoji-folder segment was `(?:[^/\n]*\s)?`, which
+#   excludes only `/` and newline — NOT quotes or shell metacharacters. So it
+#   happily swallowed `Brain" && cat > "📓 ` and the root collapsed one level to
+#   the vault's PARENT (`/Users/x`).
+#
+#   That parent is a real directory, so the hook did NOT fail open. It blocked,
+#   naming a marker path (`/Users/x/⚙️ Meta/.journal-context/<date>.json`) that
+#   no preflight can ever create. The guard became UNSATISFIABLE: every save
+#   needed JOURNAL_CONTEXT_BYPASS=1, which is exactly the "bypass becomes
+#   routine" failure that voids the guard.
+#
+# WHY A TIGHTENED REGEX ALONE IS NOT THE FIX
+#   Excluding quotes stops the WRONG root but leaves NO root (the journal path
+#   is relative — there is no absolute root in it to find), so the hook fails
+#   open and silently stops guarding the primary save path. Both halves are
+#   asserted here: the bogus root must be gone AND the correct root must be
+#   recovered from the `cd` target / payload cwd.
+#
+# Asserted against the shipped hook (module import + real stdin payloads), never
+# a reimplementation. Every claim carries a control.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+HOOK="$REPO_ROOT/hooks/warn-journal-saved-without-context.py"
+PY="${PYTHON:-python3}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+VAULT="$TMP/Brain"
+mkdir -p "$VAULT/📓 Journals/May 2026"
+mkdir -p "$VAULT/⚙️ Meta/.journal-context"
+
+failures=0
+check() { # label got want
+  if [ "$2" = "$3" ]; then printf 'PASS  %s\n' "$1"
+  else printf 'FAIL  %s (got %s, want %s)\n' "$1" "$2" "$3"; failures=$((failures + 1)); fi
+}
+
+REL_CMD="cd \"$VAULT\" && cat > \"📓 Journals/May 2026/entry.md\" << 'EOF'
+---
+creationDate: 2026-05-04
+---
+body
+EOF"
+
+# --- layer 1: unit — the parser must not invent a root above the vault -------
+"$PY" - "$REPO_ROOT" "$VAULT" <<'PYEOF'
+import importlib.util, pathlib, sys
+
+repo, vault = pathlib.Path(sys.argv[1]), sys.argv[2]
+spec = importlib.util.spec_from_file_location(
+    "journal_guard", repo / "hooks" / "warn-journal-saved-without-context.py")
+m = importlib.util.module_from_spec(spec)
+sys.modules["journal_guard"] = m
+try:
+    spec.loader.exec_module(m)
+except SystemExit:
+    pass
+
+parent = str(pathlib.Path(vault).parent)
+cmd = m._norm('cd "%s" && cat > "\U0001F4D3 Journals/May 2026/entry.md" << \'EOF\'' % vault)
+fails = 0
+
+def check(label, got, want):
+    global fails
+    if got == want:
+        print("PASS  %s" % label)
+    else:
+        print("FAIL  %s (got %r, want %r)" % (label, got, want))
+        fails += 1
+
+check("gate opens on the relative journal path", bool(m.JOURNAL_PATH_RE.search(cmd)), True)
+# The regression itself: the parent must never be returned as the vault root.
+check("cd-relative save does NOT resolve to the vault's parent",
+      m._vault_root(cmd) != parent, True)
+# And the correct root must actually be recovered, not merely fail open.
+check("cd-relative save resolves to the cd target",
+      m._resolve_vault(cmd, None), vault)
+
+# --- controls: absolute-path behaviour must be unchanged --------------------
+check("CONTROL: absolute POSIX path still resolves",
+      m._vault_root(m._norm("/Users/me/v/\U0001F4D3 Journals/May 2026/e.md")), "/Users/me/v")
+check("CONTROL: absolute path wins over an unrelated cd target",
+      m._resolve_vault(m._norm("cd /tmp && cat > '/Users/me/v/Journals/May 2026/e.md'"), "/nope"),
+      "/Users/me/v")
+check("CONTROL: no cd and no absolute path falls back to payload cwd",
+      m._resolve_vault(m._norm('cat > "Journals/May 2026/e.md"'), "/some/cwd"), "/some/cwd")
+# A wrapped/subshell cd must resolve too: falling back to cwd in a worktree
+# session picks a root with no meta dir and blocks unsatisfiably again.
+check("wrapped `bash -c 'cd ... && cat > ...'` resolves to the cd target",
+      m._resolve_vault(m._norm(
+          'bash -c \'cd "%s" && cat > "\U0001F4D3 Journals/May 2026/e.md"\'' % vault),
+          "/worktree/cwd"), vault)
+check("CONTROL: non-journal path does not open the gate",
+      bool(m.JOURNAL_PATH_RE.search(m._norm("/Users/me/v/Notes/x.md"))), False)
+
+sys.exit(1 if fails else 0)
+PYEOF
+check "unit layer" "$?" "0"
+
+# --- layer 2: end-to-end — deny names a SATISFIABLE marker path -------------
+payload() { "$PY" -c '
+import json,sys
+print(json.dumps({"tool_name":"Bash","hook_event_name":"PreToolUse",
+                  "cwd":sys.argv[2],"tool_input":{"command":sys.argv[1]}}))' "$1" "$2"; }
+
+# Decode the hook JSON rather than grepping raw stdout: json.dumps escapes the
+# non-ASCII meta dir, so a literal grep for the marker path never matches even
+# when the hook is perfectly correct.
+reason() { "$PY" -c '
+import json,sys
+raw = sys.stdin.read().strip()
+if not raw:
+    print("__ALLOW__"); raise SystemExit
+print(json.loads(raw)["hookSpecificOutput"]["permissionDecisionReason"])'; }
+
+OUT="$(payload "$REL_CMD" "$VAULT" | JOURNAL_CONTEXT_BYPASS= "$PY" "$HOOK" | reason || true)"
+check "marker absent -> denies" \
+      "$(printf '%s' "$OUT" | grep -c '^BLOCKED by warn-journal-saved-without-context' || true)" "1"
+check "deny names the real vault, not its parent" \
+      "$(printf '%s' "$OUT" | grep -cF -- "$VAULT/⚙️ Meta/.journal-context/2026-05-04.json" || true)" "1"
+check "deny does NOT name the vault's parent" \
+      "$(printf '%s' "$OUT" | grep -cF -- "$TMP/⚙️ Meta" || true)" "0"
+check "remediation names an absolute preflight path" \
+      "$(printf '%s' "$OUT" | grep -cF -- "$VAULT/⚙️ Meta/scripts/journal-preflight.py" || true)" "1"
+check "remediation uses a working interpreter (not bare python3)" \
+      "$(printf '%s' "$OUT" | grep -c 'uv run python3' || true)" "1"
+
+# The marker the message names must be the one that unblocks the save.
+touch "$VAULT/⚙️ Meta/.journal-context/2026-05-04.json"
+OUT2="$(payload "$REL_CMD" "$VAULT" | JOURNAL_CONTEXT_BYPASS= "$PY" "$HOOK" | reason || true)"
+check "marker present -> allows (guard is satisfiable)" "$OUT2" "__ALLOW__"
+
+# CONTROL: the guard still blocks a genuinely contextless save elsewhere.
+OTHER="$TMP/Other"; mkdir -p "$OTHER/📓 Journals/May 2026" "$OTHER/⚙️ Meta"
+OUT3="$(payload "cd \"$OTHER\" && cat > \"📓 Journals/May 2026/e.md\"
+creationDate: 2026-05-04" "$OTHER" | JOURNAL_CONTEXT_BYPASS= "$PY" "$HOOK" | reason || true)"
+check "CONTROL: unmarked vault still blocked" \
+      "$(printf '%s' "$OUT3" | grep -c '^BLOCKED by warn-journal-saved-without-context' || true)" "1"
+
+echo
+if [ "$failures" -ne 0 ]; then echo "FAILED: $failures check(s)"; exit 1; fi
+echo "OK: journal guard resolves cd-relative vault roots"


### PR DESCRIPTION
Recovered commit `86e71ea`, authored 2026-08-31, which had been sitting unpushed on a local `main` checkout. It existed in exactly one place on disk and was also what blocked that checkout from fast-forwarding, so the machine silently stopped receiving starter updates.

Contents (unchanged from the original commit):

- `hooks/warn-journal-saved-without-context.py` — resolve the vault root for `cd`-relative saves
- `scripts/sync-vault-scripts.sh` — revive vault script sync
- `skills/daily-journal/SKILL.md`
- `tests/integration/test_journal_guard_relative_cd_path.sh` — new coverage

Opening it as a PR rather than pushing to `main`, per the repo's usual flow.